### PR TITLE
samples: add long timeout sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Samples are in the [`samples/`](https://github.com/googleapis/java-optimization/
 | --------------------------- | --------------------------------- | ------ |
 | Async Api | [source code](https://github.com/googleapis/java-optimization/blob/main/samples/snippets/src/main/java/com/example/optimizationai/AsyncApi.java) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/java-optimization&page=editor&open_in_editor=samples/snippets/src/main/java/com/example/optimizationai/AsyncApi.java) |
 | Sync Api | [source code](https://github.com/googleapis/java-optimization/blob/main/samples/snippets/src/main/java/com/example/optimizationai/SyncApi.java) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/java-optimization&page=editor&open_in_editor=samples/snippets/src/main/java/com/example/optimizationai/SyncApi.java) |
+| Sync Api With Long Timeout | [source code](https://github.com/googleapis/java-optimization/blob/main/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/java-optimization&page=editor&open_in_editor=samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java) |
 
 
 

--- a/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
+++ b/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud;
+
+// [START cloudoptimization_long_timeout]
+
+import com.google.cloud.optimization.v1.FleetRoutingSettings;
+import com.google.cloud.optimization.v1.FleetRoutingClient;
+import com.google.cloud.optimization.v1.OptimizeToursRequest;
+import com.google.cloud.optimization.v1.OptimizeToursResponse;
+import com.google.protobuf.Duration;
+import com.google.protobuf.TextFormat;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+/**
+ * This is an example to send a request to Cloud Fleet Routing synchronous API via Java API Client.
+ */
+public class SyncApiWithLongTimeout {
+  public static void SyncApiWithLongTimeout() throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectParent = "projects/{YOUR_GCP_PROJECT_ID}";
+    String modelPath = "YOUR_MODEL_PATH";
+    SyncApiWithLongTimeout(projectParent, modelPath);
+  }
+  private static final String MODEL_PATH = "request.textproto";
+
+  public static void SyncApiWithLongTimeout(String projectParent, String modelPath) throws Exception {
+    int timeoutSeconds = 100;
+    InputStream modelInputstream = new FileInputStream(modelPath);
+    Reader modelInputStreamReader = new InputStreamReader(modelInputstream);
+    OptimizeToursRequest.Builder requestBuilder =
+        OptimizeToursRequest.newBuilder()
+            .setTimeout(Duration.newBuilder().setSeconds(timeoutSeconds).build())
+            .setParent(projectParent);
+    TextFormat.getParser().merge(modelInputStreamReader, requestBuilder);
+    
+    // Checks the gRPC connection every 5 mins and keeps it alive.
+    FleetRoutingClient fleetRoutingClientClient = FleetRoutingClient.create(
+                FleetRoutingSettings
+                .newBuilder()
+                        .setTransportChannelProvider(
+                                FleetRoutingSettings.
+                                        defaultGrpcTransportProviderBuilder()
+                                        .setKeepAliveTime(
+                                                org.threeten.bp.Duration.ofSeconds(300)).build()).build());
+    OptimizeToursResponse response = fleetRoutingClientClient.optimizeTours(requestBuilder.build());
+    System.out.println(response.toString());
+  }
+}
+// [END cloudoptimization_long_timeout]

--- a/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
+++ b/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
@@ -39,7 +39,6 @@ public class SyncApiWithLongTimeout {
     String modelPath = "YOUR_MODEL_PATH";
     longTimeout(projectParent, modelPath);
   }
-  private static final String MODEL_PATH = "request.textproto";
 
   public static void longTimeout(
       String projectParent, String modelPath) throws Exception {

--- a/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
+++ b/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
@@ -40,8 +40,7 @@ public class SyncApiWithLongTimeout {
     longTimeout(projectParent, modelPath);
   }
 
-  public static void longTimeout(
-      String projectParent, String modelPath) throws Exception {
+  public static void longTimeout(String projectParent, String modelPath) throws Exception {
     int timeoutSeconds = 100;
     InputStream modelInputstream = new FileInputStream(modelPath);
     Reader modelInputStreamReader = new InputStreamReader(modelInputstream);
@@ -50,16 +49,16 @@ public class SyncApiWithLongTimeout {
             .setTimeout(Duration.newBuilder().setSeconds(timeoutSeconds).build())
             .setParent(projectParent);
     TextFormat.getParser().merge(modelInputStreamReader, requestBuilder);
-    
+
     // Checks the gRPC connection every 5 mins and keeps it alive.
-    FleetRoutingClient fleetRoutingClientClient = FleetRoutingClient.create(
-                FleetRoutingSettings
-                .newBuilder()
-                        .setTransportChannelProvider(
-                                FleetRoutingSettings
-                                        .defaultGrpcTransportProviderBuilder()
-                                        .setKeepAliveTime(org.threeten.bp.Duration.ofSeconds(300))
-                                        .build()).build());
+    FleetRoutingClient fleetRoutingClientClient =
+        FleetRoutingClient.create(
+            FleetRoutingSettings.newBuilder()
+                .setTransportChannelProvider(
+                    FleetRoutingSettings.defaultGrpcTransportProviderBuilder()
+                        .setKeepAliveTime(org.threeten.bp.Duration.ofSeconds(300))
+                        .build())
+                .build());
     OptimizeToursResponse response = fleetRoutingClientClient.optimizeTours(requestBuilder.build());
     System.out.println(response.toString());
   }

--- a/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
+++ b/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.cloud;
 
 // [START cloudoptimization_long_timeout]
 
-import com.google.cloud.optimization.v1.FleetRoutingSettings;
 import com.google.cloud.optimization.v1.FleetRoutingClient;
+import com.google.cloud.optimization.v1.FleetRoutingSettings;
 import com.google.cloud.optimization.v1.OptimizeToursRequest;
 import com.google.cloud.optimization.v1.OptimizeToursResponse;
 import com.google.protobuf.Duration;
@@ -32,15 +33,16 @@ import java.io.Reader;
  * This is an example to send a request to Cloud Fleet Routing synchronous API via Java API Client.
  */
 public class SyncApiWithLongTimeout {
-  public static void SyncApiWithLongTimeout() throws Exception {
+  public static void longTimeout() throws Exception {
     // TODO(developer): Replace these variables before running the sample.
     String projectParent = "projects/{YOUR_GCP_PROJECT_ID}";
     String modelPath = "YOUR_MODEL_PATH";
-    SyncApiWithLongTimeout(projectParent, modelPath);
+    longTimeout(projectParent, modelPath);
   }
   private static final String MODEL_PATH = "request.textproto";
 
-  public static void SyncApiWithLongTimeout(String projectParent, String modelPath) throws Exception {
+  public static void longTimeout(
+      String projectParent, String modelPath) throws Exception {
     int timeoutSeconds = 100;
     InputStream modelInputstream = new FileInputStream(modelPath);
     Reader modelInputStreamReader = new InputStreamReader(modelInputstream);
@@ -55,10 +57,10 @@ public class SyncApiWithLongTimeout {
                 FleetRoutingSettings
                 .newBuilder()
                         .setTransportChannelProvider(
-                                FleetRoutingSettings.
-                                        defaultGrpcTransportProviderBuilder()
-                                        .setKeepAliveTime(
-                                                org.threeten.bp.Duration.ofSeconds(300)).build()).build());
+                                FleetRoutingSettings
+                                        .defaultGrpcTransportProviderBuilder()
+                                        .setKeepAliveTime(org.threeten.bp.Duration.ofSeconds(300))
+                                        .build()).build());
     OptimizeToursResponse response = fleetRoutingClientClient.optimizeTours(requestBuilder.build());
     System.out.println(response.toString());
   }

--- a/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
+++ b/samples/snippets/src/main/java/com/example/optimizationai/SyncApiWithLongTimeout.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud;
+package com.example.optimizationai;
 
 // [START cloudoptimization_long_timeout]
 

--- a/samples/snippets/src/test/java/com/example/optimizationai/SyncApiWithLongTimeoutTest.java
+++ b/samples/snippets/src/test/java/com/example/optimizationai/SyncApiWithLongTimeoutTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.optimizationai;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for SyncApiWithLongTimeout sample. */
+public class SyncApiWithLongTimeoutTest {
+  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String PROJECT_PARENT = String.format("projects/%s", PROJECT_ID);
+  private static final String MODEL_PATH = "resources/sync_request.textproto";
+
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+  private PrintStream originalPrintStream;
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    originalPrintStream = System.out;
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() {
+    System.out.flush();
+    System.setOut(originalPrintStream);
+  }
+
+  @Test
+  public void testSyncApi() throws Exception {
+    SyncApi.callSyncApi(PROJECT_PARENT, MODEL_PATH);
+    String got = bout.toString();
+    assertThat(got).contains("routes");
+  }
+}

--- a/samples/snippets/src/test/java/com/example/optimizationai/SyncApiWithLongTimeoutTest.java
+++ b/samples/snippets/src/test/java/com/example/optimizationai/SyncApiWithLongTimeoutTest.java
@@ -50,7 +50,7 @@ public class SyncApiWithLongTimeoutTest {
 
   @Test
   public void testSyncApi() throws Exception {
-    SyncApi.callSyncApi(PROJECT_PARENT, MODEL_PATH);
+    SyncApiWithLongTimeout.longTimeout(PROJECT_PARENT, MODEL_PATH);
     String got = bout.toString();
     assertThat(got).contains("routes");
   }


### PR DESCRIPTION
This code snippet is very similar to the SyncAPI sample here: https://github.com/googleapis/java-optimization/blob/main/samples/snippets/src/main/java/com/example/optimizationai/SyncApi.java
The purpose of this sample is to explain how to use the keep-alive setting to send a sync request with long timeout.